### PR TITLE
Fix tooltip predicates assignment in SlotLoader

### DIFF
--- a/src/main/java/eu/pb4/trinkets/impl/data/SlotLoader.java
+++ b/src/main/java/eu/pb4/trinkets/impl/data/SlotLoader.java
@@ -127,7 +127,7 @@ public class SlotLoader extends SimplePreparableReloadListener<Map<String, Group
 			Identifier finalIcon = icon == null || icon.isEmpty() ? null : Identifier.parse(icon);
 			SlotTypeImpl.Condition finalValidatorPredicates = validatorPredicates;
 			SlotTypeImpl.Condition finalQuickMovePredicates = quickMovePredicates;
-			SlotTypeImpl.Condition finalTooltipPredicates = finalValidatorPredicates;
+			SlotTypeImpl.Condition finalTooltipPredicates = tooltipPredicates;
 
 			if (finalValidatorPredicates == null) {
 				finalValidatorPredicates = new SlotTypeImpl.DirectCondition(DEFAULT_VALIDATOR_PREDICATES);


### PR DESCRIPTION
This part fixes it so that, if you have a slot that every item is accepted in, it doesn't add a message to every single slot out there