### PR TITLE
prevent Invalid player data on dedicated servers

### DIFF
--- a/src/main/java/eu/pb4/trinkets/mixin/InventoryMenuMixin.java
+++ b/src/main/java/eu/pb4/trinkets/mixin/InventoryMenuMixin.java
@@ -4,7 +4,7 @@ import com.google.common.collect.ImmutableList;
 import eu.pb4.trinkets.api.*;
 import eu.pb4.trinkets.impl.*;
 import eu.pb4.trinkets.impl.client.TrinketsClient;
-import eu.pb4.trinkets.mixin.client.accessor.ScreenHandlerAccessor;
+import eu.pb4.trinkets.mixin.accessor.ScreenHandlerAccessor;
 import it.unimi.dsi.fastutil.ints.Int2ObjectMap;
 import it.unimi.dsi.fastutil.ints.Int2ObjectOpenHashMap;
 import net.minecraft.world.entity.player.Inventory;

--- a/src/main/java/eu/pb4/trinkets/mixin/accessor/ScreenHandlerAccessor.java
+++ b/src/main/java/eu/pb4/trinkets/mixin/accessor/ScreenHandlerAccessor.java
@@ -1,4 +1,4 @@
-package eu.pb4.trinkets.mixin.client.accessor;
+package eu.pb4.trinkets.mixin.accessor;
 
 import net.minecraft.core.NonNullList;
 import net.minecraft.world.inventory.AbstractContainerMenu;

--- a/src/main/resources/trinkets.mixins.json
+++ b/src/main/resources/trinkets.mixins.json
@@ -13,6 +13,7 @@
     "PlayerListMixin",
     "ServerGamePacketListenerImplMixin",
     "ServerPlayerMixin",
+    "accessor.ScreenHandlerAccessor",
     "behaviour.LivingEntityMixin",
     "behaviour.PiglinAiMixin",
     "client.ItemPickerMenuAccessor",
@@ -30,8 +31,7 @@
     "client.abi.TrinketRendererMixin",
     "client.accessor.CreativeSlotAccessor",
     "client.accessor.LivingEntityAccessor",
-    "client.accessor.RecipeBookScreenAccessor",
-    "client.accessor.ScreenHandlerAccessor"
+    "client.accessor.RecipeBookScreenAccessor"
   ],
   "injectors": {
     "defaultRequire": 1


### PR DESCRIPTION
When my mod depended on Trinkets, I encountered this error ([https://pastebin.com/W7SsTutY](https://pastebin.com/W7SsTutY)) when trying to join a dedicated server. I eventually traced the issue to a mixin that was incorrectly (I think) defined as client-only, yet was still being loaded on the server. This problem only occurred when my mod was enabled.
