### PR TITLE
Fix: Correct tooltip color

### DIFF
--- a/src/main/java/eu/pb4/trinkets/impl/ItemStackTooltipUtil.java
+++ b/src/main/java/eu/pb4/trinkets/impl/ItemStackTooltipUtil.java
@@ -177,13 +177,15 @@ public class ItemStackTooltipUtil {
                 }
 
 
+                ChatFormatting color = attribute.value().getStyle(g > 0.0D);
+                
                 if (g > 0.0D) {
                     textConsumer.accept(Component.translatable("attribute.modifier.plus." + modifier.operation().id(),
-                            ItemAttributeModifiers.ATTRIBUTE_MODIFIER_FORMAT.format(g), text).withStyle(ChatFormatting.BLUE));
+                            ItemAttributeModifiers.ATTRIBUTE_MODIFIER_FORMAT.format(g), text).withStyle(color));
                 } else if (g < 0.0D) {
                     g *= -1.0D;
                     textConsumer.accept(Component.translatable("attribute.modifier.take." + modifier.operation().id(),
-                            ItemAttributeModifiers.ATTRIBUTE_MODIFIER_FORMAT.format(g), text).withStyle(ChatFormatting.RED));
+                            ItemAttributeModifiers.ATTRIBUTE_MODIFIER_FORMAT.format(g), text).withStyle(color));
                 }
             }
         }


### PR DESCRIPTION
The tooltip color used to only take into account the increase/decrease of an attribute, but now it also takes into account its sentiment
That is, if a bad attribute (like attack cooldown) is decreasing, it will be blue, which makes sense, rather than red